### PR TITLE
fix: the lfs_malloc wrapper in lfs_util in lfs_util.h

### DIFF
--- a/littleFS/lfs_util.h
+++ b/littleFS/lfs_util.h
@@ -229,9 +229,13 @@ uint32_t lfs_crc(uint32_t crc, const void *buffer, size_t size);
 // byte-level buffers.
 static inline void *lfs_malloc(size_t size) {
 #if defined(LFS_MALLOC)
-    return LFS_MALLOC(size);
+    void *p = LFS_MALLOC(size);
+    LFS_ASSERT(p != NULL);
+    return p;
 #elif !defined(LFS_NO_MALLOC)
-    return malloc(size);
+    void *p = malloc(size);
+    LFS_ASSERT(p != NULL);
+    return p;
 #else
     (void)size;
     return NULL;


### PR DESCRIPTION
## Summary
Fix high severity security issue in `littleFS/lfs_util.h`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-003 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-003` |
| **File** | `littleFS/lfs_util.h:230` |

**Description**: The lfs_malloc wrapper in lfs_util.h calls either LFS_MALLOC (FreeRTOS pvPortMalloc) or stdlib malloc() depending on configuration. The wrapper itself does not check for NULL returns. On embedded ARM Cortex-M devices without MMU, writes through a NULL pointer corrupt memory at address 0, which typically contains the interrupt vector table, enabling code execution.

## Changes
- `littleFS/lfs_util.h`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
