### PR TITLE
Fix: guard McuI2cLib_ResetBus with MCUI2CLIB_CONFIG_I2C_RELEASE_BUS

### DIFF
--- a/src/McuI2cLib.c
+++ b/src/McuI2cLib.c
@@ -279,10 +279,12 @@ static void McuI2cLib_ConfigureI2cPins(void) {
 #endif
 }
 
+#if MCUI2CLIB_CONFIG_I2C_RELEASE_BUS
 bool McuI2cLib_ResetBus(void) {
   ResetI2CBus(); /* reset I2C bus */
   return true; /* success */
 }
+#endif /* MCUI2CLIB_CONFIG_I2C_RELEASE_BUS */
 
 void McuI2cLib_Deinit(void) {
   /* nothing implemented */

--- a/src/McuI2cLib.h
+++ b/src/McuI2cLib.h
@@ -31,7 +31,9 @@ uint8_t McuI2cLib_SelectSlave(uint8_t Slv);
 uint8_t McuI2cLib_ReadAddress(uint8_t i2cAddr, uint8_t *memAddr, uint8_t memAddrSize, uint8_t *data, uint16_t dataSize);
 uint8_t McuI2cLib_WriteAddress(uint8_t i2cAddr, uint8_t *memAddr, uint8_t memAddrSize, uint8_t *data, uint16_t dataSize);
 
+#if MCUI2CLIB_CONFIG_I2C_RELEASE_BUS
 bool McuI2cLib_ResetBus(void);
+#endif
 
 void McuI2cLib_Deinit(void);
 void McuI2cLib_Init(void);


### PR DESCRIPTION
### Description ###

On platforms where `MCUI2CLIB_CONFIG_I2C_RELEASE_BUS == 0` (e.g. ESP32) the `McuI2cLib_ResetBus()` is still declared and defined (see `McuI2cLib.h` and `McuI2cLib.c`), but its body calls `ResetI2CBus()` which is only defined when `MCUI2CLIB_CONFIG_I2C_RELEASE_BUS == 1`.

### Tests ###
Tested locally with an esp-idf project (build passes).

### P.S. ###

Grüsse cdb